### PR TITLE
Added support to get the most recent reviews of an app

### DIFF
--- a/src/crawler/config.yaml
+++ b/src/crawler/config.yaml
@@ -8,6 +8,7 @@ Apps:
       #country,lang
       - us, en
       - in, en
+    reviews_order: "most recent"
 
   dropbox :
     package_name : 'com.dropbox.android' #dropbox
@@ -15,9 +16,11 @@ Apps:
       #country,lang
       - us, en
       - in, en
+    reviews_order: "most relevant"
 
   mega :
     package_name : 'mega.privacy.android.app' #mega
     geographies_languages:
       - us, en
       - in, en
+    reviews_order: "most recent"

--- a/src/crawler/config.yaml
+++ b/src/crawler/config.yaml
@@ -23,4 +23,4 @@ Apps:
     geographies_languages:
       - us, en
       - in, en
-    reviews_order: "most recent"
+    reviews_order: 

--- a/src/crawler/main.py
+++ b/src/crawler/main.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2021 core.ai (https://core.ai/) 
+# (C) Copyright 2021 core.ai (https://core.ai/)
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,17 +21,18 @@ import argparse
 # scraper = Crawler('config.yaml')
 # scraper.crawl()
 
-parser =argparse.ArgumentParser(prog='App Info Extracter', usage='''python main.py <file> ''',
-description='''Description:
+parser = argparse.ArgumentParser(prog='App Info Extracter',
+                                 usage='''python main.py <file> ''',
+                                 description='''Description:
 App info extractor is a utility to extract and analyze customer reviews and critical metrics of apps from multiple
 sources like google play store, Apple play store, and anyother sources.This utility is highly configurable to extract
 and give relevant information about any app in a meaningful way.''',
-formatter_class=argparse.RawDescriptionHelpFormatter,
-add_help=True
-)
+                                 formatter_class=argparse.RawDescriptionHelpFormatter,
+                                 add_help=True
+                                 )
 parser.add_argument("file", type=str,
-help="config.yaml file containing the configuration for each app"
-)
+                    help="config.yaml file containing the configuration for each app"
+                    )
 arg = parser.parse_args()
 scraper = Crawler(arg.file)
 scraper.crawl()

--- a/src/crawler/scraper.py
+++ b/src/crawler/scraper.py
@@ -25,7 +25,8 @@ from enum import Enum
 
 
 class Scrapper:
-    def __init__(self, name_of_app, package_name, country, lang, reviews_order):
+    def __init__(self, name_of_app, package_name,
+                 country, lang, reviews_order):
         if not package_name or not lang or not country or not name_of_app:
             raise ValueError("Invalid parameters passed for scrapping")
         self.name_of_app = name_of_app
@@ -78,9 +79,9 @@ class Scrapper:
         print(table)
 
     def __sort_reviews(self):
-        if Reviews_order(self.reviews_order).name == 'MOST_RECENT':
+        if Reviews_order(self.reviews_order) == Reviews_order.MOST_RECENT:
             return Sort.NEWEST  # get most recent reviews
-        elif Reviews_order(self.reviews_order).name == 'MOST_RELEVANT':
+        elif Reviews_order(self.reviews_order) == Reviews_order.MOST_RELEVANT:
             return Sort.MOST_RELEVANT  # get most relevant reviews
 
     def __scrap_reviews(self, score):
@@ -134,7 +135,7 @@ class Crawler:
         jobs = []
         package_name = package_info['package_name']
         reviews_order = package_info['reviews_order']
-        if reviews_order == None:  # no value is specified
+        if reviews_order is None:  # no value is specified
             reviews_order = "most relevant"  # so get most relevant reviews
         for country_lang in package_info['geographies_languages']:
             split = country_lang.split(',')

--- a/src/crawler/scraper.py
+++ b/src/crawler/scraper.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2021 core.ai (https://core.ai/) 
+# (C) Copyright 2021 core.ai (https://core.ai/)
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,16 +21,18 @@ from google_play_scraper import app, reviews_all, Sort
 from utils import Utils
 import time
 from tabulate import tabulate
+from enum import Enum
 
 
 class Scrapper:
-    def __init__(self, name_of_app, package_name, country, lang):
+    def __init__(self, name_of_app, package_name, country, lang, reviews_order):
         if not package_name or not lang or not country or not name_of_app:
             raise ValueError("Invalid parameters passed for scrapping")
         self.name_of_app = name_of_app
         self.package_name = package_name
         self.lang = lang
         self.country = country
+        self.reviews_order = reviews_order
         app_info = app(self.package_name, self.lang, self.country)
         del app_info["comments"]
         Utils.print_json(app_info)
@@ -75,13 +77,19 @@ class Scrapper:
         table = tabulate(results_to_print, ['Score', 'Number Of Entries'])
         print(table)
 
+    def __sort_reviews(self):
+        if Reviews_order(self.reviews_order).name == 'MOST_RECENT':
+            return Sort.NEWEST      #get most recent reviews
+        elif Reviews_order(self.reviews_order).name == 'MOST_RELEVANT' :
+            return Sort.MOST_RELEVANT       #get most relevant reviews
+
     def __scrap_reviews(self, score):
         result = reviews_all(
             self.package_name,
             sleep_milliseconds=0,  # defaults to 0
             lang=self.lang,  # defaults to 'en'
             country=self.country,  # defaults to 'us'
-            sort=Sort.MOST_RELEVANT,  # defaults to Sort.MOST_RELEVANT
+            sort=self.__sort_reviews(),  # decide the order of reviews to scrap
             filter_score_with=score,  # defaults to None(means all score)
         )
         self.reviews[score] = result
@@ -125,10 +133,17 @@ class Crawler:
     def __prepare_package_for_crawling(self, package, package_info):
         jobs = []
         package_name = package_info['package_name']
+        reviews_order = package_info['reviews_order']
         for country_lang in package_info['geographies_languages']:
             split = country_lang.split(',')
             country = split[0].strip()
             lang = split[1].strip()
-            scrapper = Scrapper(package, package_name, country, lang)
+            scrapper = Scrapper(package, package_name,
+                                country, lang, reviews_order)
             jobs.append(scrapper)
         return jobs
+
+
+class Reviews_order(Enum):
+    MOST_RELEVANT = "most relevant"
+    MOST_RECENT = "most recent"

--- a/src/crawler/scraper.py
+++ b/src/crawler/scraper.py
@@ -79,9 +79,9 @@ class Scrapper:
 
     def __sort_reviews(self):
         if Reviews_order(self.reviews_order).name == 'MOST_RECENT':
-            return Sort.NEWEST      #get most recent reviews
-        elif Reviews_order(self.reviews_order).name == 'MOST_RELEVANT' :
-            return Sort.MOST_RELEVANT       #get most relevant reviews
+            return Sort.NEWEST  # get most recent reviews
+        elif Reviews_order(self.reviews_order).name == 'MOST_RELEVANT':
+            return Sort.MOST_RELEVANT  # get most relevant reviews
 
     def __scrap_reviews(self, score):
         result = reviews_all(
@@ -134,6 +134,8 @@ class Crawler:
         jobs = []
         package_name = package_info['package_name']
         reviews_order = package_info['reviews_order']
+        if reviews_order == None:  # no value is specified
+            reviews_order = "most relevant"  # so get most relevant reviews
         for country_lang in package_info['geographies_languages']:
             split = country_lang.split(',')
             country = split[0].strip()


### PR DESCRIPTION
A new field `reviews_order` added to "config.yaml" to specify most recent or most relevant reviews to be crawled.
If it's value is `"most recent"` , the most recent reviews are crawled.
If it's value is `"most relevant"` , the most relevant reviews are crawled.
If no value is given in the field, most relevant reviews are crawled.
#1 